### PR TITLE
Add feature to debug tests with Playwright

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,7 +41,7 @@ To run this project:
 2. Install the playwright dependencies
 
     ```bash
-    playwright install
+    playwright install --with-deps
     ```
 
 3. Then you may run pytest with this simple command
@@ -54,4 +54,30 @@ To run this project:
 
     ```bash
     pytest --headed --browser chromium --browser firefox --browser webkit
+    ```
+
+5. To run in debug mode, run the following code:
+
+    ```bash
+    pytest --headed --debug
+    ```
+
+    You may or may not specify browsers
+
+6. To run a specific test file, run the following code:
+
+    ```bash
+    pytest -k test_filename
+    ```
+
+    To run a specific test from a test file:
+
+    ```bash
+    pytest -k test_name
+    ```
+
+    The same flags from steps 4 and 5 can still work. For example:
+
+    ```bash
+    pytest -k test_sample --browser chromium --headed --debug
     ```

--- a/pages/base_page.py
+++ b/pages/base_page.py
@@ -1,3 +1,4 @@
+import sys
 from dataclasses import dataclass
 from decimal import Decimal
 
@@ -61,6 +62,13 @@ class SauceDemoBasePage:
 
     def __init__(self, page: Page) -> None:
         self.page = page
+
+        # emulate `npx playwright test --debug`
+        # from JavaScript, to use run the following
+        # command: `python -m pytest --headed --debug`
+        # NOTE: flag '--headed' is neccessary
+        if "--debug" in sys.argv:
+            self.pause()
 
     def pause(self) -> None:
         self.page.pause()


### PR DESCRIPTION
Emulate the behavior of `npx playwright --debug` in JavaScript projects

To run, use the following command:
```
pytest --headed --debug
```

NOTE: the `--headed` flag is necessary for the Playwright UI to show